### PR TITLE
Fix favorite button when filtering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -44,7 +44,7 @@ $(function() {
 	});
 
 	$(document).ready(function() {
-    $('[id^="favorite-button"]').click(function (e) {
+		$(document).on("click", '[class^="favorite-button"]', function(e) {
 				var button = $(event.target).parent();
         if(e.target.classList.contains("glyphicon-star")) {
 					button.removeClass('starred')

--- a/app/views/camps/_camp_card.html.erb
+++ b/app/views/camps/_camp_card.html.erb
@@ -2,8 +2,8 @@
 <%= stylesheet_link_tag 'spectrum.css' %>
 <div class='card camp-<%=camp.id %> <%= css_classes if defined?(css_classes)%>'>
     <% if user_signed_in? %>
-        <%= link_to toggle_favorite_camp_path(:id => camp.id), method: :patch, class: (camp.favorite_users.include?(current_user) ? 'favorite-button starred' : 'favorite-button'), id: 'favorite-button', :remote => true do %>
-            <span id="star-icon" class="glyphicon < %= camp.favorite_users.include?(current_user) ? 'glyphicon-star' : 'glyphicon-star-empty' %>"></span>
+        <%= link_to toggle_favorite_camp_path(:id => camp.id), method: :patch, class: (camp.favorite_users.include?(current_user) ? 'favorite-button starred' : 'favorite-button'), :remote => true do %>
+            <span id="star-icon" class="glyphicon <%= camp.favorite_users.include?(current_user) ? 'glyphicon-star' : 'glyphicon-star-empty' %>"></span>
         <% end %>
     <% end %>
     <a href="<%= url_for(camp) %>">

--- a/app/views/camps/show.html.erb
+++ b/app/views/camps/show.html.erb
@@ -56,7 +56,7 @@
                     <p>
                         <%= @camp.display_name %>
                         <% if user_signed_in? %>
-                            <%= link_to :toggle_favorite_camp, method: :patch, class: (@camp.favorite_users.include?(current_user) ? 'favorite-button starred' : 'favorite-button'), id: 'favorite-button', style: "position: absolute;", :remote => true do %>
+                            <%= link_to :toggle_favorite_camp, method: :patch, class: (@camp.favorite_users.include?(current_user) ? 'favorite-button starred' : 'favorite-button'), style: "position: absolute;", :remote => true do %>
                                 <span id="star-icon" class="glyphicon <%= @camp.favorite_users.include?(current_user) ? 'glyphicon-star' : 'glyphicon-star-empty' %>"></span>
                             <% end %>
                         <% end %>


### PR DESCRIPTION
- creates an event listener on the document that looks for clicks on things with class `favorite-button` that will work on new elements from the filter results as well
- removes a space that made the favorite star not show at all