### PR TITLE
Remove controversy toggle on action related to filterrific

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -56,6 +56,19 @@ $(function() {
           button.find("#star-icon").addClass('glyphicon-star')
         }
 		});
+
+		// remove list-view-toggle from dom when someone interacts with
+		// filterrific because filteriffic breaks list view
+		$('#filterrific_filter').change(function(e){
+			$("#grid-view").show();
+			$("#table-view").hide();
+			$("#list-view-toggle").remove()
+		})
+		$('#filterrific_filter').keydown(function(e){
+			$("#grid-view").show();
+			$("#table-view").hide();
+			$("#list-view-toggle").remove()
+		})
 		
 		$(function() {
 			$("#toggle").click(function() {

--- a/app/assets/stylesheets/camps.css.scss
+++ b/app/assets/stylesheets/camps.css.scss
@@ -792,6 +792,8 @@ body {
 
 #table-view {
   display:none;
+  margin: 0 auto;
+  margin-top: 40px;
 
   th {
     text-align: center;

--- a/app/views/camps/_list.html.erb
+++ b/app/views/camps/_list.html.erb
@@ -12,5 +12,20 @@
         </div>
 
     </div>
-
 </div>
+
+<table id='table-view' style='display: none'>
+    <tr>
+        <th>Dream name</th>
+        <th>Monster actions</th>
+        <th>Approvers</th>
+    </tr>
+    <% @camps.count_all_flags.each do |camp_id, flag_sum| %>
+    <% @the_camp = @camps.where(['id = ?', camp_id])[0] %>
+    <tr>
+        <% if @the_camp%>
+            <%= render :partial => 'camps/camp_row', locals: { camp: @the_camp, flag_sum: flag_sum } %>
+        <%end%>
+    </tr>
+    <% end %>
+</table>

--- a/app/views/camps/index.html.erb
+++ b/app/views/camps/index.html.erb
@@ -67,7 +67,7 @@
         <script>
 
         </script>
-        <div class='list-view-toggle'>
+        <div class='list-view-toggle' id='list-view-toggle'>
         <span class='toggle-label'>Monsters Count</span>
         <form>
           <label class="switch">


### PR DESCRIPTION
I make sure that the controversy view doesn't throw an error when filterrific does its magic and disable the controversy view altogether when someone interacts with filterrific form.

This way dream guides can still use the feature after being instructed that the controversy view is only available when you don't use filterrific. Hacky but I hope it's fine for now (don't have time to rebuild the whole thing).

@aerugo I couldn't check if the monsters count works correctly due to the difference between 'count' and 'COUNT(*)' on dev and prod.

Fixes #66